### PR TITLE
Travis ci support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - "node"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 node_js:
-  - "node"
+  - "8"
+  - "10"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "rm -rf lib mod && tsc -p tsconfig.build.json && tsc -p tsconfig.module.json",
     "lint": "tslint -c tslint.json -p tsconfig.json",
     "test": "npm run lint && jest",
-    "prepare": "npm run test && npm run build"
+    "prepublishOnly": "npm run test && npm run build"
   },
   "author": "Fitbit, Inc.",
   "license": "BSD-3-Clause",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "rm -rf lib mod && tsc -p tsconfig.build.json && tsc -p tsconfig.module.json",
     "lint": "tslint -c tslint.json -p tsconfig.json",
-    "test": "jest",
+    "test": "npm run lint && jest",
     "prepare": "npm run test && npm run build"
   },
   "author": "Fitbit, Inc.",

--- a/src/decode.test.ts
+++ b/src/decode.test.ts
@@ -1,6 +1,6 @@
 import * as t from 'io-ts';
 
-import { decode, DecodeError } from './decode';
+import { decode } from './decode';
 
 // Lifted from the io-ts README
 // tslint:disable-next-line:variable-name

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -3,8 +3,6 @@ import ErrorSubclass from 'error-subclass';
 import * as t from 'io-ts';
 import { failure } from 'io-ts/lib/PathReporter';
 
-import { Peer } from './peer';
-
 export class DecodeError extends ErrorSubclass {
   static displayName = 'DecodeError';
 }


### PR DESCRIPTION
- Add `.travis.yml` file, will run tests with Node version 8 and 10.
- Add lint step to `test` script
- Change `prepare` to `prepublishOnly` so travis does not run tests on `yarn install`
- Fix any linting errors.