### PR TITLE
Improve RPC peer error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fitbit/jsonrpc-ts",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "A very flexible library for building JSON-RPC 2.0 endpoints.",
   "files": [
     "lib",
@@ -37,6 +37,6 @@
     "error-subclass": "^2.2.0"
   },
   "peerDependencies": {
-    "io-ts": "1.4.1"
+    "io-ts": "^1.4.2"
   }
 }


### PR DESCRIPTION
Define a new error hierarchy for being unable to complete a method call.
Reject method call Promises with instances of the `MethodCallError`
subclasses `MethodCallTimeout` or `RPCStreamClosed` in response to the
respective events.

Define a new error class `UnexpectedResponse`, and emit that instead of
a plain `Error` when receiving an unexpected JSON-RPC response object.

Reject the method call Promise instead of throwing when calling
`callMethod` while the RPC stream is already closed, for consistency
with the RPC stream closing while the response is pending.

No longer assert that the Writable side of the Peer is open in the
`sendNotification` and `pushError` methods. This is consistent with the
behaviour of the `Readable.push` method, and allows Peer to be operated
in a simplex mode for sending notifications. This change also fixes a
bug with handling of a request handler's error response when the
Writable side is closed. Before, success responses were pushed to the
Readable side but errors resulted in an unhandled Promise rejection
within the library and no response being pushed. Now all responses are
pushed to the Readable side irrespective of the response type or state
of the Peer's Writable side.